### PR TITLE
change(docker): create a fully packaged Docker container + automatic Docker build

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:
@@ -29,7 +31,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: mattiadevivo/modbustools
+          images: ${{ vars.DOCKER_REPOSITORY }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # type=semver will be used on a push tag event, it removes the prepending v from the tag
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         id: push
@@ -44,6 +51,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
+          subject-name: index.docker.io/${{ vars.DOCKER_REPOSITORY }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,49 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: mattiadevivo/modbustools
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 # tells apt not to prompt for user input, debconf for package configuration, and setting it to noninteractive ensures that any configuration questions are skipped or assigned default values.
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y build-essential
+RUN apt update && apt install -y build-essential git cmake
 RUN apt install -y qtbase5-dev qttools5-dev
-RUN apt install -y git
-RUN apt install -y cmake
 
 RUN git clone --recursive https://github.com/serhmarch/ModbusTools.git
 
@@ -18,14 +16,45 @@ RUN cmake --build .
 RUN cmake --build . --config Debug
 RUN cmake --build . --config Release
 
-COPY <<'EOF' ./entrypoint.sh
-#!/bin/bash
-./server &
-./client 
+RUN yes | rm -r /app/ModbusTools
+
+# install vnc server and vnc proxy to make the vnc server accessible via web
+RUN apt install -y xvfb x11vnc fluxbox novnc supervisor
+
+COPY <<'EOF' supervisord.conf
+[supervisord]
+nodaemon=true
+logfile=/dev/null  
+loglevel=debug      
+
+[program:Xvfb]
+command=/usr/bin/Xvfb :1 -screen 0 1600x900x16
+priority=1
+
+[program:x11vnc]
+command=/usr/bin/x11vnc -display :1 -ncache 0 -forever -shared -nopw
+priority=2
+
+[program:fluxbox]
+command=/usr/bin/fluxbox
+environment=DISPLAY=:1
+priority=3
+
+[program:novnc]
+command=/usr/bin/websockify --web=/usr/share/novnc/ --cert=/home/ubuntu/novnc.pem 6080 localhost:5900
+priority=4
+
+[program:server]
+command=/app/bin/server
+environment=DISPLAY=:1
+priority=5
+
+[program:client]
+command=/app/bin/client
+environment=DISPLAY=:1
+priority=6
 EOF
-RUN chmod +x ./entrypoint.sh
 
-# we need the display env var to be set to the proper host's Xserver in order to be able to run a GUI app in the docker container
-ENV DISPLAY=
+EXPOSE 6080
 
-ENTRYPOINT ["/bin/bash", "-c", "./entrypoint.sh"]
+CMD ["/usr/bin/supervisord", "-c", "supervisord.conf"]

--- a/src/README.md
+++ b/src/README.md
@@ -217,15 +217,17 @@ cmake --build --preset "Linux-Release"
 
 ## Build Docker Image
 
-Make sure you have a Xserver running on your host machine.
+The application will be compiled and run inside a Docker container.
+The GUIs will be exposed via a web server on port 6080.
 
 1. Build the Docker image
 
    ```console
-   docker build -t modbustool .
+   docker build --platform=linux/amd64 -t modbustool .
    ```
 
 2. Run the docker image
    ```console
-   docker run --platform=linux/amd64 -e DISPLAY=host.docker.internal:0 modbustools
+   docker run -p 6080:6080 modbustools
    ```
+3. Access the application at `http://localhost:6080/vnc.html`


### PR DESCRIPTION
This PR introduces two related changes to improve the Docker experience and automation.

### Dockerfile Update
The Docker container now includes an embedded VNC server. This allows the GUI to be accessed via a web browser, eliminating the need for any setup on the host machine (e.g., no need for a VNC client). This enhances the ease of use and accessibility for users who run the container that will just need to access the url `http://localhost:6080/vnc.html` on their machine.

### GitHub Workflow for Docker Image Updates
Added a GitHub Actions workflow to automatically build and push updated Docker images to the registry. This ensures that the Docker image is always up-to-date with the latest changes in the repository without requiring manual intervention.

### Setup Instructions for the GitHub Workflow
In order for the GitHub workflow to function correctly, the following steps are required:
- create a DockerHub Repository: you will need to create a repository on DockerHub to store the built images.
- set repository Environment Variables: set the `DOCKER_REPOSITORY` environment variable to the `Secrets and Variables > Actions > Repository variables` section in the repository settings to point to your DockerHub repository.
- add Docker Credentials as Secrets: add the `DOCKER_USERNAME` and `DOCKER_PASSWORD` to the `Secrets and Variables > Actions > Repository secret` section in the repository settings to authenticate with DockerHub during the image push process.

These changes streamline the process of running ModbusTools in Docker and automate image updates, providing a smoother user experience and better CI/CD practices.