### PR TITLE
.gitignore: add build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ TODO
 __pycache__/
 *.py[cod]
 *$py.class
+
+# CMake build directories
+/build*


### PR DESCRIPTION
Hi! This is a really small commit that just excludes common build directories from git, so you can do an build in a "normal" build sub-directory without having to avoid `git add`ing it. Also means the build output don't get picked up by IDEs if they have "filter by VCS ignore files" enabled.